### PR TITLE
fix: hoist useMemo calls above early returns in ActivityLog

### DIFF
--- a/src/components/ActivityLog.tsx
+++ b/src/components/ActivityLog.tsx
@@ -102,6 +102,16 @@ export function ActivityLog() {
   const [searchFilter, setSearchFilter] = useState("");
   const deferredSearchFilter = useDeferredValue(searchFilter);
 
+  const filtered = useMemo(() => {
+    if (!entries) return [];
+    if (!deferredSearchFilter) return entries;
+    const needle = deferredSearchFilter.toLowerCase();
+    return entries.filter((e) => e.source.toLowerCase().includes(needle));
+  }, [entries, deferredSearchFilter]);
+
+  const items = useMemo(() => groupIntoHourlyBuckets(filtered), [filtered]);
+  const dateGroups = useMemo(() => groupByDate(items), [items]);
+
   if (isLoading) {
     return (
       <div className="text-center py-8 text-text-secondary text-sm">
@@ -119,16 +129,6 @@ export function ActivityLog() {
       </div>
     );
   }
-
-  const filtered = useMemo(() => {
-    if (!entries) return [];
-    if (!deferredSearchFilter) return entries;
-    const needle = deferredSearchFilter.toLowerCase();
-    return entries.filter((e) => e.source.toLowerCase().includes(needle));
-  }, [entries, deferredSearchFilter]);
-
-  const items = useMemo(() => groupIntoHourlyBuckets(filtered), [filtered]);
-  const dateGroups = useMemo(() => groupByDate(items), [items]);
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Moves three `useMemo` hooks above the `isLoading` and empty-state early returns in `ActivityLog.tsx`
- Fixes `react-hooks/rules-of-hooks` violations at lines 123, 130, 131 that were blocking CI (Lint Frontend)
- No behavioral change — the `useMemo` bodies already guard against `null`/empty `entries`

## Test plan
- [ ] `npm run lint` passes with 0 errors
- [ ] Activity log renders correctly with no entries, loading state, and populated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)